### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/function-mqtests/pom.xml
+++ b/function-mqtests/pom.xml
@@ -145,7 +145,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>  

--- a/function-schoolmaster2/etc/function-documentFlow-new/pom.xml
+++ b/function-schoolmaster2/etc/function-documentFlow-new/pom.xml
@@ -203,7 +203,7 @@
 		<dependency>
 			  <groupId>commons-collections</groupId>
 			  <artifactId>commons-collections</artifactId>
-			  <version>3.2.1</version>
+			  <version>3.2.2</version>
 		</dependency>
 		
 		

--- a/function-syllabus/pom.xml
+++ b/function-syllabus/pom.xml
@@ -169,7 +169,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>

--- a/function-weixin/pom.xml
+++ b/function-weixin/pom.xml
@@ -121,7 +121,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.python</groupId>

--- a/function-weixin/pomweb.txt
+++ b/function-weixin/pomweb.txt
@@ -154,7 +154,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate</groupId>  

--- a/sm2/pom.xml
+++ b/sm2/pom.xml
@@ -134,7 +134,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>spy</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
